### PR TITLE
(DOCS) Update links to docs

### DIFF
--- a/control-repo-contents.md
+++ b/control-repo-contents.md
@@ -179,6 +179,6 @@ automated testing, and documentation.
 
 For foundational technical information, please see the documents linked below.
 
-* https://docs.puppet.com/pe/latest/cmgmt_control_repo.html
-* https://docs.puppet.com/puppet/latest/config_file_environment.html#modulepath
-* https://docs.puppet.com/pe/latest/code_mgr.html
+* https://puppet.com/docs/pe/latest/control_repo.html
+* https://puppet.com/docs/puppet/latest/config_file_environment.html#modulepath
+* https://puppet.com/docs/pe/latest/code_mgr_how_it_works.html

--- a/puppet-code-abstraction-profiles.md
+++ b/puppet-code-abstraction-profiles.md
@@ -105,4 +105,4 @@ of each Profile may need to change to accommodate for multiple tenancy.
 
 ## Other Information
 
-* https://docs.puppet.com/pe/latest/r_n_p_intro.html
+* https://puppet.com/docs/pe/latest/the_roles_and_profiles_method.html

--- a/puppet-code-abstraction-roles.md
+++ b/puppet-code-abstraction-roles.md
@@ -109,4 +109,4 @@ of each Role may need to change to accommodate for multiple tenancy.
 
 ## Other Information
 
-* https://docs.puppet.com/pe/latest/r_n_p_intro.html
+* https://puppet.com/docs/pe/latest/the_roles_and_profiles_method.html

--- a/separate-hieradata-repository.md
+++ b/separate-hieradata-repository.md
@@ -171,5 +171,5 @@ with one of the acceptable methods detailed in this best practice.
 # Other Information
 
 * https://support.puppet.com/hc/en-us/articles/226118987
-* https://docs.puppet.com/pe/2016.5/cmgmt_puppetfile.html#specify-install-paths-for-repositories
-* https://docs.puppet.com/pe/latest/code_mgr.html
+* https://puppet.com/docs/pe/latest/puppetfile.html#specify-installation-paths-for-repositories
+* https://puppet.com/docs/pe/latest/code_mgr_how_it_works.html

--- a/use-of-environment-in-hiera-hierarchy.md
+++ b/use-of-environment-in-hiera-hierarchy.md
@@ -143,7 +143,7 @@ level.
 Configuration of the Hiera hierarchy should not be confused with configuration
 of the Hiera datadir. `%{environment}` can and should be used to configure the
 Hiera datadir. This is already [the default datadir
-configuration](https://docs.puppet.com/hiera/3.2/configuring.html#default-config-values).
+configuration](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html#the-default-configuration).
 
 ## Alternate Options
 


### PR DESCRIPTION
Some links point to the older docs.puppet.com domain, or to outdated
pages and anchors. One link points to an outdated Hiera v3 doc. Update
those links.