### PR TITLE
Import README from old cs-standards repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# best-practices
+# CS Best Practices Repository
+
+Customers, partners, and Puppet employees have long sought standards for the implementation and configuration of Puppet Enterprise and related software. These standards aren't official technical documentation, but rather a distillation of the collective experience of our team and community. This repository was created to give CS a place to compile these standards using a standard process to propose, define, review, and revise them.
+
+## Scope
+
+This repo attempts to contain all Customer Success standards. It should not be considered a complete reference for all things Puppet, and only represents the collective opinions of the Customer Success department at Puppet, Inc. with respect to the specified Puppet design, workflow, and architecture details.
+
+A standard, for purposes of this repository, is defined as an authoritative process, approach, or method for implementing and using Puppet software. Standards in this repository describe a general purpose preference, and should not necessarily be considered the only acceptable way to use the software. They are, however, the preferred approach excluding any extenuating circumstances clearly understood by the implementer.
+
+This repository is **not**:
+
+- A collection of how-to guides for advanced or beginner Puppet use
+- A replacement for the documentation available at [docs.puppet.com](https://docs.puppet.com)
+- A blog, journal, or timely record keeping location
+- A location to store usable code
+- A location for storing procedures that are irrelevant to non-employees or
+  non-partners of Puppet, Inc.
+
+Content in this repository should be modeled after an [IETF RFC](https://www.ietf.org/rfc.html), but should not include content that is already released as part of the official Puppet documentation.
+
+## Contributing
+
+All members of Customer Success are invited to contribute, either by filing issues to request a new standard, or helping in the process to create new standards. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) guide to get started.


### PR DESCRIPTION
The CS Standards repo had a _much_ better README than this repo,
but this repo has become the "winner" and the cs-standards repo
will be deprecated and archived soon. Taking some of the good
content and moving it here.