### PR TITLE
Clean up imported README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
-# CS Best Practices Repository
+# Customer Success Best Practices Repository
 
-Customers, partners, and Puppet employees have long sought standards for the implementation and configuration of Puppet Enterprise and related software. These standards aren't official technical documentation, but rather a distillation of the collective experience of our team and community. This repository was created to give CS a place to compile these standards using a standard process to propose, define, review, and revise them.
+Customers, partners, and Puppet employees have long sought standards for the implementation and configuration of Puppet's products and related software. These best practices are not official technical documentation, but rather a distillation of the collective experience of our team and community. This repository was created to give Customer Success a place to compile these practices using a standard process to propose, define, review, and revise them.
 
 ## Scope
 
-This repo attempts to contain all Customer Success standards. It should not be considered a complete reference for all things Puppet, and only represents the collective opinions of the Customer Success department at Puppet, Inc. with respect to the specified Puppet design, workflow, and architecture details.
+This repo attempts to contain all of Customer Success' opinionated best practices, it should not be considered a complete reference for all things Puppet. It will represent the collective field experiences of the Customer Success department at Puppet, with respect to the specified design, workflow, and architecture details of Puppet's various pieces of software.
 
-A standard, for purposes of this repository, is defined as an authoritative process, approach, or method for implementing and using Puppet software. Standards in this repository describe a general purpose preference, and should not necessarily be considered the only acceptable way to use the software. They are, however, the preferred approach excluding any extenuating circumstances clearly understood by the implementer.
+A best practice, for purposes of this repository, is defined as an authoritative process, approach, or method for implementing and using some aspect of Puppet's software. Best practices' in this repository describe a general purpose preference, and should not necessarily be considered the only acceptable way to use the software. They are, however, the preferred approach excluding any extenuating circumstances clearly understood by the implementer.
 
 This repository is **not**:
 
-- A collection of how-to guides for advanced or beginner Puppet use
+- A collection of how-to guides outlining advanced nor simple Puppet uses
 - A replacement for the documentation available at [docs.puppet.com](https://docs.puppet.com)
 - A blog, journal, or timely record keeping location
 - A location to store usable code
-- A location for storing procedures that are irrelevant to non-employees or
-  non-partners of Puppet, Inc.
+- A location for storing procedures that are irrelevant to non-employees or non-partners of Puppet
 
-Content in this repository should be modeled after an [IETF RFC](https://www.ietf.org/rfc.html), but should not include content that is already released as part of the official Puppet documentation.
+Content in this repository should be modeled after an [IETF RFC](https://www.ietf.org/standards/rfcs/) and should not include content that is already released as part of the official Puppet documentation.
 
 ## Contributing
 
-All members of Customer Success are invited to contribute, either by filing issues to request a new standard, or helping in the process to create new standards. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) guide to get started.
+Everyone is invited to contribute, either by filing issues against existing best practices or by helping in the process to create new standards.


### PR DESCRIPTION
	Re-wording of README imported from defunct cs-standards
	repository to make more sense in the context of the best
	practices repository.