### PR TITLE
Links

### DIFF
--- a/puppet-code-abstraction-profiles.md
+++ b/puppet-code-abstraction-profiles.md
@@ -105,4 +105,4 @@ of each Profile may need to change to accommodate for multiple tenancy.
 
 ## Other Information
 
-* https://puppet.com/docs/pe/latest/the_roles_and_profiles_method.html
+* https://puppet.com/docs/pe/latest/osp/the_roles_and_profiles_method.html

--- a/puppet-code-abstraction-roles.md
+++ b/puppet-code-abstraction-roles.md
@@ -109,4 +109,4 @@ of each Role may need to change to accommodate for multiple tenancy.
 
 ## Other Information
 
-* https://puppet.com/docs/pe/latest/the_roles_and_profiles_method.html
+* https://puppet.com/docs/pe/latest/osp/the_roles_and_profiles_method.html


### PR DESCRIPTION
2019.8 and 2021.0 docs now include /osp/ in the path for the roles and profiles method.